### PR TITLE
allow HyperTextLiteral v0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,5 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-HypertextLiteral = "0.6, 0.7, 0.8"
+HypertextLiteral = "0.6, 0.7, 0.8, 0.9"
 julia = "1"


### PR DESCRIPTION
Currently, compat for HypertextLiteral is set to v0.6 to 0.8. The most recent version of HypertextLiteral, 0.9, is not supported.
This causes issues when using PlutoTest together with other packages which require HypertextLiteral 0.9.

I do not think that there are breaking changes, therefore it should be sufficient just to add a compat entry for 0.9.