### PR TITLE
Show test pass at first frame

### DIFF
--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -1414,7 +1414,7 @@ p-frame-controls {
 """)
 
 # ╔═╡ e968fc57-d850-4e2d-9410-8777d03b7b3c
-function frames(fs::Vector, startframe = nothing)
+function frames(fs::Vector; startframe::Union{Nothing,Int}=nothing)
 	l = length(fs)
 	
 	startframe = if isnothing(startframe)
@@ -1623,7 +1623,10 @@ begin
 			<pt-dot class="floating top"></pt-dot>
 			<pt-dot class="floating bottom"></pt-dot>
 		
-			$(frames(SlottedDisplay.( call.steps)))
+			$(frames(
+				SlottedDisplay.( call.steps);
+				startframe=isa(call,Pass) ? 1 : nothing,
+			))
 		</div>
 		<style>
 		$(pluto_test_css.code)


### PR DESCRIPTION
Currently, we always show the second-to-last frame as the default, until you move the timeline:

<img src="https://user-images.githubusercontent.com/6933510/157498311-17d84278-2987-427b-b10f-b5da5667b62a.png" width=400>

This makes sense for test *failures*, because probably the last function call went from computed results to `false`, like a `==` call. But for test passes, it often just shows something trivial.

This PR makes the *first* frame the default for test passes. This means that you can hide all code, and sort of quickly see what was being tested:

<img src="https://user-images.githubusercontent.com/6933510/157498698-3d3c35c7-6c9b-4c3b-a35a-e6e8dd594a33.png" width=400>

But as you see in the screenshot, a large test expression means that it takes up more vertical space...